### PR TITLE
Fixed issue with regions

### DIFF
--- a/src/main/scala/com/github/tptodorov/sbt/cloudformation/CloudFormation.scala
+++ b/src/main/scala/com/github/tptodorov/sbt/cloudformation/CloudFormation.scala
@@ -165,7 +165,8 @@ object CloudFormation extends AutoPlugin {
 
       val credentials = (awsCredentials in config).value
       val client = new AmazonCloudFormationClient(credentials)
-      client.setRegion(Region.getRegion(Regions.fromName(region)))
+      
+      client.setRegion(Region.getRegion(Regions.valueOf(region)))
       client
     },
     stackDescribe in config := {


### PR DESCRIPTION
The PR fixes an issue where cloud formation plugin fails with the error below:

```
[trace] Stack trace suppressed: run last sbt-native-packager-test/staging:stackClient for the full output.
[error] (sbt-native-packager-test/staging:stackClient) java.lang.IllegalArgumentException: Cannot create enum from US_WEST_2 value!
[error] Total time: 0 s, completed 22 Aug 2016 1:43:38 AM
```

Can you please review/merge it when you get a moment?
